### PR TITLE
refacto: move interpreter related classes to their own files 

### DIFF
--- a/aoc2020/day8/instructions.py
+++ b/aoc2020/day8/instructions.py
@@ -1,0 +1,50 @@
+import re
+from typing import Literal, Union
+
+from pydantic import BaseModel, Field
+
+
+class Acc(BaseModel):
+    code: Literal["acc"]
+    value: int = Field(..., alias="arg1")
+
+
+class Nop(BaseModel):
+    code: Literal["nop"]
+    unused: int = Field(..., alias="arg1")
+
+
+class Jmp(BaseModel):
+    code: Literal["jmp"]
+    offset: int = Field(..., alias="arg1")
+
+
+Instruction = Union[
+    Acc, Nop, Jmp
+]
+
+
+# Pretty pointless class that simply saves me the trouble
+# of iterating over the Union type myself.
+#
+# Right now we could simply get the instruction type simply
+# by looking at the code, but it's likely that in the future
+# it may be a bit more complicated (e.g. `jmp +4` vs `jmp @4`,
+# relative vs absolute jumps).
+#
+# Using a Union type instead of simply subclassing also means
+# we can check for exhaustiveness.
+class _InstructionBuilder(BaseModel):
+    __root__: Instruction
+
+
+_regex = "(?P<code>\\w{3}) (?P<arg1>(\\+|-)\\d+)"
+_compiled = re.compile(_regex)
+
+
+def instruction_parser(line: str) -> Instruction:
+    if match := re.match(_compiled, line):
+        return _InstructionBuilder.parse_obj(match.groupdict()).__root__
+    else:
+        raise ValueError(f"Unknown instruction {line}")
+

--- a/aoc2020/day8/interpreter.py
+++ b/aoc2020/day8/interpreter.py
@@ -1,0 +1,40 @@
+from dataclasses import field, dataclass
+from typing import List, Set
+
+from aoc2020.day8.instructions import Instruction, Acc, Nop, Jmp
+from aoc2020.shared.typing_utils import assert_never
+
+
+class LoopDetected(RuntimeError):
+    def __init__(self, acc: int):
+        self.final_accumulator_value = acc
+
+
+@dataclass
+class Interpreter:
+    instructions: List[Instruction]
+    _accumulator: int = field(init=False, default=0)
+    _current_index: int = field(init=False, default=0)
+    _visited_indices: Set[int] = field(init=False, default_factory=set)
+
+    def run(self) -> int:
+        while True:
+            if self._current_index in self._visited_indices:
+                raise LoopDetected(self._accumulator)
+            if self._current_index >= len(self.instructions):
+                return self._accumulator
+            self.run_step()
+
+    def run_step(self) -> None:
+        self._visited_indices.add(self._current_index)
+        current_instruction = self.instructions[self._current_index]
+
+        if isinstance(current_instruction, Acc):
+            self._accumulator += current_instruction.value
+            self._current_index += 1
+        elif isinstance(current_instruction, Nop):
+            self._current_index += 1
+        elif isinstance(current_instruction, Jmp):
+            self._current_index += current_instruction.offset
+        else:
+            assert_never(current_instruction.code)


### PR DESCRIPTION
This is in preparation for the almost inevitable problem that'll reuse what we did on day8.

Hopefully this is a bit easier to extend.

Especially, having the instruction each in its own (unrelated) class should make it nicer to add more of those.